### PR TITLE
fix: apply igraph's stricter argument naming policy

### DIFF
--- a/R/policy_graph.R
+++ b/R/policy_graph.R
@@ -219,7 +219,7 @@ policy_graph <-
     
     if (remove_unreachable_nodes)
       policy_graph <- igraph::delete_vertices(policy_graph, setdiff(seq_along(V(policy_graph)), 
-        igraph::dfs(policy_graph, root = initial_pg_node, unreach = FALSE)$order))
+        igraph::dfs(policy_graph, root = initial_pg_node, unreachable = FALSE)$order))
 
     policy_graph
   }


### PR DESCRIPTION
:wave: @mhahsler! In igraph, we're [adding dots](https://github.com/igraph/rigraph/pull/1523/) between required and optional arguments as seen in https://design.tidyverse.org/dots-after-required.html The new check will pick up argument names that have been abbreviated (Note that partial matching is not recommended in the tidyverse style guide https://style.tidyverse.org/syntax.html#argument-names -- not that you have to follow this style guide in general, this comment is for context), resulting in an error. 

This PR is fixing it for pomdp. Would you be able to soon make a release of your package on CRAN?